### PR TITLE
Bump base image to alpine:3.23 to clear CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
     && curl -sL "https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_Linux-${ARCH}.tar.gz" \
        | tar -xz -C /usr/local/bin s5cmd
 
-FROM alpine:3.21
+FROM alpine:3.23
 WORKDIR /app
 
 RUN apk add --no-cache \


### PR DESCRIPTION
## Summary

Rebuilds the runtime stage against `alpine:3.23` so the next image carries fixed packages for the 3 CRITICAL / 25 HIGH CVEs Trivy flagged on `v3.0.1` (`alpine:3.21` runtime, last built 2026-02-26).

- `Dockerfile`: `FROM alpine:3.21` → `FROM alpine:3.23`
- `s5cmd` left at `2.3.0` (still the latest upstream release as of today).
- `debian:trixie-slim` builder is unpinned by digest, so a rebuild already pulls fresh apt packages — no source change needed there.

Fixes #5

## Test plan

- [ ] CI: shellcheck, trivy fs, semgrep all green
- [ ] After merge: tag `v3.0.2`, confirm Docker Hub publishes multi-arch image
- [ ] `trivy image joanfabregat/mysql-s3-backup:v3.0.2 --severity CRITICAL,HIGH --ignore-unfixed` reports 0/0 (or near-zero)
- [ ] Bump pin in `fogandfrog/veolia-sophos-infra` (`overlays/production/mariadb-backup.yaml`) to `v3.0.2`
