### PR TITLE
Rebuild image to clear Trivy CRITICAL/HIGH (source-build s5cmd + apk upgrade)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,25 @@
-FROM debian:trixie-slim AS s5cmd-builder
+# Build s5cmd from source with a current Go toolchain so the binary embeds an
+# up-to-date Go stdlib. The upstream prebuilt release tarballs are compiled with
+# an old Go (v2.3.0 ships Go 1.22.10), which Trivy flags for stdlib CVEs.
+FROM golang:1.26-alpine AS s5cmd-builder
 
 ARG S5CMD_VERSION=2.3.0
-ARG TARGETARCH
+ENV CGO_ENABLED=0
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
-    && ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "64bit") \
-    && curl -sL "https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_Linux-${ARCH}.tar.gz" \
-       | tar -xz -C /usr/local/bin s5cmd
+RUN go install \
+    -ldflags "-X=github.com/peak/s5cmd/v2/version.Version=v${S5CMD_VERSION}" \
+    "github.com/peak/s5cmd/v2@v${S5CMD_VERSION}"
 
 FROM alpine:3.23
 WORKDIR /app
 
-RUN apk add --no-cache \
+RUN apk upgrade --no-cache \
+    && apk add --no-cache \
     bash \
     mariadb-client \
     gzip
 
-COPY --from=s5cmd-builder /usr/local/bin/s5cmd /usr/local/bin/s5cmd
+COPY --from=s5cmd-builder /go/bin/s5cmd /usr/local/bin/s5cmd
 
 COPY backup.sh .
 


### PR DESCRIPTION
## Summary

Fixes #7 — `joanfabregat/mysql-s3-backup:v3.0.2` (deployed as the `mariadb-backup` CronJob in Veolia Sophos prod) scans at **1 CRITICAL / 14+ HIGH**. I verified the findings locally with `trivy image` before and after the change, which showed the issue's suggested fix (`apk upgrade` alone) would **not** clear most of them.

## What the scan actually showed

`trivy image joanfabregat/mysql-s3-backup:v3.0.2 --severity CRITICAL,HIGH`:

| Target | Findings | Root cause | Cleared by |
|---|---|---|---|
| alpine 3.23.4 (`libcrypto3`/`libssl3`) | 1 HIGH (CVE-2026-45447) | OpenSSL patched upstream; base layer was frozen | `apk upgrade --no-cache` |
| `s5cmd` (gobinary, Go **stdlib**) | **1 CRITICAL + 14 HIGH** | upstream prebuilt v2.3.0 is compiled with **Go 1.22.10** | building s5cmd from source with a current Go toolchain |

The CRITICAL (CVE-2025-68121, crypto/tls cert validation) and all 14 HIGH are Go stdlib CVEs baked into the s5cmd binary. The old builder just **re-downloaded the same prebuilt tarball**, so a plain rebuild — or `apk upgrade` alone — left every one of them in place. s5cmd is already at its latest release (v2.3.0, Dec 2024), so there is no newer tag to move to; compiling from source is the fix.

## Changes

- Builder stage: `debian:trixie-slim` + download prebuilt tarball → `golang:1.26-alpine` + `go install github.com/peak/s5cmd/v2@v2.3.0` (CGO disabled, version injected via `-ldflags`).
- Final stage: add `apk upgrade --no-cache` to refresh pre-installed base packages.

## Verification (local, linux/amd64)

| Image | alpine | gobinary |
|---|---|---|
| published `v3.0.2` | 2 HIGH | 1 CRITICAL + 14 HIGH |
| `apk upgrade` only | **0** | 1 CRITICAL + 14 HIGH |
| **this PR** (source-build + `apk upgrade`) | **0** | **0** |

- `s5cmd version` → `v2.3.0` ✅
- `shellcheck backup.sh` → clean ✅

## After merge

Cut **v3.0.3** (triggers the multi-arch build/push), then bump the pin in `veolia-sophos-infra` (`overlays/production/mariadb-backup.yaml`) `v3.0.2` → `v3.0.3`.

> Note: CI's Trivy step is a **filesystem** scan, so it never sees these base/binary CVEs. A follow-up could add a `trivy image` scan to the build workflow to gate future publishes.