### PR TITLE
ci: add Trivy image scan to catch base/binary CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,38 @@ jobs:
           severity: CRITICAL,HIGH
           exit-code: 1
 
+  trivy-image:
+    name: Trivy image scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build the actual image (amd64) and load it locally so Trivy can scan the
+      # built layers. The filesystem scan above only sees repo files; it cannot
+      # catch CVEs in the Alpine base packages or in the s5cmd Go binary — which
+      # is exactly where the findings in issue #7 lived.
+      - name: Build image for scanning
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: mysql-s3-backup:scan
+
+      # ignore-unfixed: only fail on CVEs that have an upstream fix available
+      # (the actionable set). Without it, an unfixable upstream CVE would block
+      # every build until the dependency cuts a release.
+      - name: Run Trivy image scan
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: image
+          image-ref: mysql-s3-backup:scan
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: 1
+
   semgrep:
     name: Semgrep SAST
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Follow-up to #7. The existing `Trivy security scan` job is a **filesystem** scan (`scan-type: fs`) — it only sees repo files, so it never inspects the Alpine base packages or the s5cmd Go binary. Every finding in #7 lived in exactly those layers, which is why CI stayed green while the published image scanned at 1 CRITICAL / 14+ HIGH.

This adds a `trivy-image` job that builds the image (amd64, `load: true`) and runs a **Trivy image scan** against the built layers, gating PRs on `CRITICAL,HIGH`.

## Notes

- `ignore-unfixed: true` keeps the gate to the **actionable** set — CVEs with an upstream fix available. Without it, an unfixable upstream CVE (e.g. a future s5cmd-only stdlib issue with no release yet) would block every build indefinitely.
- Single-arch (amd64) build is sufficient — these base/binary CVEs are arch-independent.
- The existing `fs` scan is kept (it catches different things, e.g. vulnerable refs in repo manifests).

## Limitation

This is a **build-time** gate: it catches problems at PR time, not image rot that happens *after* publish (a base image going stale weeks later). Closing that gap fully would need a scheduled rescan/rebuild — out of scope here.