### PR TITLE
ci: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           scandir: .
           severity: warning
@@ -22,10 +22,10 @@ jobs:
     name: Trivy security scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -36,17 +36,17 @@ jobs:
     name: Trivy image scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       # Build the actual image (amd64) and load it locally so Trivy can scan the
       # built layers. The filesystem scan above only sees repo files; it cannot
       # catch CVEs in the Alpine base packages or in the s5cmd Go binary — which
       # is exactly where the findings in issue #7 lived.
       - name: Build image for scanning
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           load: true
@@ -56,7 +56,7 @@ jobs:
       # (the actionable set). Without it, an unfixable upstream CVE would block
       # every build until the dependency cuts a release.
       - name: Run Trivy image scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
           image-ref: mysql-s3-backup:scan
@@ -70,7 +70,7 @@ jobs:
     container:
       image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Run Semgrep
         run: semgrep scan --config auto --error

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,23 +12,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: joanfabregat/mysql-s3-backup
           tags: |
@@ -37,7 +37,7 @@ jobs:
             type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Fixes the Semgrep failure blocking [#10](https://github.com/joanfabregat/mysql-s3-backup/pull/10).

## The finding is correct

`github-actions-mutable-action-tag`, 15 findings across both workflows. Every action was pinned to a **mutable tag**. A tag can be repointed by its owner, or by anyone who compromises the action repository — so `@v4` is a promise, not a guarantee. The workflow runs whatever that tag resolves to at the time, with whatever secrets the job holds. For `docker/login-action` that includes registry credentials.

## What changed

All nine actions now pin the 40-character commit SHA, with the previous tag kept as a trailing comment so the intended version stays readable and Dependabot can still propose updates.

| action | was | now |
|---|---|---|
| `actions/checkout` | `v4` | `11d5960` |
| `aquasecurity/trivy-action` | `v0.36.0` | `ed142fd` |
| `docker/build-push-action` | `v5` | `ca052bb` |
| `docker/build-push-action` | `v6` | `10e90e3` |
| `docker/login-action` | `v3` | `c94ce9f` |
| `docker/metadata-action` | `v5` | `c299e40` |
| `docker/setup-buildx-action` | `v3` | `8d2750c` |
| `docker/setup-qemu-action` | `v3` | `c7c5346` |
| `ludeeus/action-shellcheck` | `2.0.0` | `00cae50` |

Each SHA was resolved **from the tag it replaces**, so this is behaviour-neutral today — it only removes the ability for those tags to move underneath us.

## Why it appeared now

Rule drift, not a regression. `semgrep scan --config auto` pulls current community rules, and `main` last ran green in April, before this rule applied. It surfaced on an unrelated PR (#10, which only touches `backup.sh`) — that PR introduced no findings of its own.

Worth knowing for the future: with `--config auto`, CI can go red without anyone changing code.
