### PR TITLE
Add MYSQL_SINGLE_TRANSACTION so dumps do not block writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This service provides a reliable way to backup MySQL databases to Amazon S3 or a
 ## Features
 
 - MySQL database dumping via `mysqldump` (with `--no-tablespaces` flag)
+- Optional `--single-transaction` dumps, so backups don't block writes (see [Dump consistency and locking](#dump-consistency-and-locking))
 - Support for both TCP and Unix socket connections
 - Automatic compression of database dumps using gzip
 - Upload to Amazon S3 or any S3-compatible provider (Backblaze B2, MinIO, etc.) via [`s5cmd`](https://github.com/peak/s5cmd)
@@ -56,6 +57,7 @@ MYSQL_USER=username
 MYSQL_PASSWORD=password
 MYSQL_DATABASE=database (supports comma-separated list, e.g. db1,db2)
 MYSQL_SOCKET=/path/to/socket (optional, for Unix socket connections)
+MYSQL_SINGLE_TRANSACTION=0 (optional, defaults to 0; see Dump consistency and locking)
 ```
 
 ### S3 / Storage Configuration
@@ -69,6 +71,63 @@ AWS_ACCESS_KEY_ID=your-access-key
 AWS_SECRET_ACCESS_KEY=your-secret-key
 AWS_DEFAULT_REGION=us-west-1
 ```
+
+## Dump consistency and locking
+
+By default `mysqldump` runs with `--lock-tables` (part of `--opt`): it takes
+`LOCK TABLES … READ LOCAL` over every table in a database and holds it for that
+database's entire dump. **Writes to those tables block for as long as the dump
+takes** — minutes on a large schema. In exchange, every table in the dump comes
+from the same point in time, whatever storage engine it uses.
+
+Setting `MYSQL_SINGLE_TRANSACTION=1` adds `--single-transaction`, which reads
+inside a transaction instead of locking. Writes are never blocked, and the backup
+user no longer needs `LOCK TABLES`.
+
+The catch: **`--single-transaction` is only a consistent snapshot of
+transactional tables.** InnoDB tables are safe. MyISAM, Aria and MEMORY tables
+are read outside the transaction, so a write landing mid-dump can tear them —
+silently, with nothing in the dump to indicate it. That is why this is opt-in and
+off by default: a backup tool should not quietly downgrade what "a valid backup"
+means on an image pull.
+
+Accepted values are `1`/`0`, `true`/`false`, `yes`/`no`, `on`/`off`. Anything
+else is rejected at startup rather than being silently treated as off.
+
+### Which one to use
+
+| | `MYSQL_SINGLE_TRANSACTION=0` (default) | `MYSQL_SINGLE_TRANSACTION=1` |
+|---|---|---|
+| Writes during the dump | Blocked | Not blocked |
+| InnoDB consistency | Yes | Yes |
+| MyISAM / Aria / MEMORY consistency | Yes | **No — can be torn** |
+| Grants needed | `SELECT, SHOW VIEW, TRIGGER, LOCK TABLES` | `SELECT, SHOW VIEW, TRIGGER` |
+
+**All-InnoDB deployment:** enable it. There is no downside.
+
+**Mixed engines:** the right fix is usually converting the remaining tables to
+InnoDB — InnoDB has supported `FULLTEXT` since MySQL 5.6, which is the common
+reason a MyISAM table is still around. Until then, leaving this off trades a
+known cost (the write stall) for a known guarantee.
+
+When enabled, the script queries `information_schema` before each dump and logs
+any non-InnoDB table it finds, so a mixed schema shows up in the backup log
+rather than in a failed restore:
+
+```
+Dumping MySQL database: mixeddb
+Warning: MYSQL_SINGLE_TRANSACTION is enabled but 'mixeddb' has non-transactional tables:
+Warning:   doc_recherche_index (MyISAM)
+Warning: these are dumped outside the transaction and a concurrent write can tear them.
+Warning: convert them to InnoDB, or unset MYSQL_SINGLE_TRANSACTION to lock instead.
+```
+
+The check is advisory: if it cannot run, it warns and the backup proceeds.
+
+Note that **neither mode gives a consistent snapshot across databases.** With a
+comma-separated `MYSQL_DATABASE`, each database is dumped by its own `mysqldump`
+invocation, so each gets its own lock or transaction window and they do not line
+up with each other.
 
 ## Installation
 
@@ -238,7 +297,7 @@ docker build -t joanfabregat/mysql-s3-backup .
 ## Security Considerations
 
 - Use IAM roles when running in AWS environments instead of hardcoded credentials
-- Create a dedicated database user with minimal permissions (SELECT, LOCK TABLES)
+- Create a dedicated database user with minimal permissions: `SELECT, SHOW VIEW, TRIGGER, LOCK TABLES`, or `SELECT, SHOW VIEW, TRIGGER` with `MYSQL_SINGLE_TRANSACTION=1` (see [Dump consistency and locking](#dump-consistency-and-locking))
 - Store sensitive environment variables using appropriate secret management solutions
 - Consider encrypting your S3 bucket to protect sensitive data
 
@@ -250,6 +309,10 @@ Common issues:
 2. **Permission denied**: Ensure the MySQL user has proper permissions for dumping
 3. **S3 upload failures**: Check AWS credentials and bucket write permissions
 4. **Out of space errors**: Ensure enough temporary storage is available
+5. **Writes stall while the backup runs**: This is `mysqldump`'s default table
+   locking. See [Dump consistency and locking](#dump-consistency-and-locking)
+6. **`Access denied … when using LOCK TABLES`**: Either grant `LOCK TABLES` to the
+   backup user, or set `MYSQL_SINGLE_TRANSACTION=1`, which does not need it
 
 ## License
 

--- a/backup.sh
+++ b/backup.sh
@@ -30,6 +30,9 @@ S3_STORAGE_CLASS="${S3_STORAGE_CLASS-STANDARD_IA}"
 # shipped 1800/900, which came to 4500s for one database and 9000s for two, so
 # the Job deadline always won and these never fired.
 #
+# With MYSQL_SINGLE_TRANSACTION enabled, add ENGINE_CHECK_TIMEOUT (30s) per
+# database to that worst case: 1530s each, 3060s for two.
+#
 # For scale: the largest current deployment dumps and uploads a ~924 MiB gzipped
 # database in about 2m05s, so 600/300 is roughly 5x observed. Raise them for a
 # genuinely larger database -- and raise activeDeadlineSeconds to match.
@@ -37,6 +40,44 @@ DUMP_TIMEOUT="${DUMP_TIMEOUT:-600}"
 UPLOAD_TIMEOUT="${UPLOAD_TIMEOUT:-300}"
 # Seconds to wait after TERM before sending KILL.
 TIMEOUT_GRACE="${TIMEOUT_GRACE:-30}"
+
+# Deliberately not tunable: the engine check is a metadata lookup against
+# information_schema, not a data read. If it has not answered in 30s the server
+# is in no state to be dumped, and DUMP_TIMEOUT will say so a moment later.
+ENGINE_CHECK_TIMEOUT=30
+
+# --single-transaction removes the write stall the default causes. Without it
+# mysqldump falls back to --lock-tables (part of --opt), which holds
+# LOCK TABLES ... READ LOCAL over every table in a database for the whole of that
+# database's dump -- minutes of blocked writes on a large schema. It also drops
+# LOCK TABLES from the grants the backup user needs.
+#
+# It is OFF by default and must stay that way. --single-transaction is only a
+# consistent snapshot of TRANSACTIONAL tables; MyISAM, Aria and MEMORY tables are
+# dumped outside the transaction and a concurrent write can tear them -- silently,
+# with nothing in the dump to show it. Enabling it for everyone would trade a
+# visible cost (a write stall) for an invisible one (an occasionally invalid
+# restore) on nothing more than an image pull, which is the wrong direction for a
+# backup tool.
+#
+# Neither mode gives a snapshot ACROSS databases: the loop below runs one
+# mysqldump per entry in MYSQL_DATABASE, so each gets its own lock or transaction
+# window and they do not line up.
+#
+# Turn it on for all-InnoDB deployments -- there it is a straight win. On mixed
+# ones the real fix is converting the stragglers (InnoDB has had FULLTEXT since
+# 5.6, which is the usual reason a MyISAM table is still around); the check in
+# warn_non_transactional_tables names them so an operator learns from the log
+# rather than from a failed restore.
+single_transaction="${MYSQL_SINGLE_TRANSACTION:-0}"
+case "${single_transaction,,}" in
+    1|true|yes|on)  single_transaction=1 ;;
+    0|false|no|off) single_transaction=0 ;;
+    *)
+        echo "Error: MYSQL_SINGLE_TRANSACTION must be a boolean (1/0, true/false, yes/no, on/off), got '${single_transaction}'" >&2
+        exit 1
+        ;;
+esac
 
 # --- Parse DATABASE_URL if set ---
 
@@ -108,19 +149,83 @@ if [[ -z "${S3_BUCKET:-}" ]]; then
     exit 1
 fi
 
-# --- Build base mysqldump arguments ---
+# --- Build connection arguments ---
 
-mysqldump_args=(-u "$MYSQL_USER" --no-tablespaces)
+# Shared by mysqldump and by the engine check below, so the check always talks to
+# the same server, as the same user, as the dump it is warning about.
+mysql_conn_args=(-u "$MYSQL_USER")
 
 if [[ -n "${MYSQL_SOCKET:-}" ]]; then
-    mysqldump_args+=(--socket "$MYSQL_SOCKET")
+    mysql_conn_args+=(--socket "$MYSQL_SOCKET")
 else
-    mysqldump_args+=(-h "$MYSQL_HOST" -P "$MYSQL_PORT")
+    mysql_conn_args+=(-h "$MYSQL_HOST" -P "$MYSQL_PORT")
 fi
 
 if [[ -n "${MYSQL_PASSWORD:-}" ]]; then
-    mysqldump_args+=("--password=${MYSQL_PASSWORD}")
+    mysql_conn_args+=("--password=${MYSQL_PASSWORD}")
 fi
+
+# --- Build base mysqldump arguments ---
+
+mysqldump_args=("${mysql_conn_args[@]}" --no-tablespaces)
+
+if (( single_transaction )); then
+    # --single-transaction turns --lock-tables off by itself, so there is nothing
+    # else to unset here.
+    mysqldump_args+=(--single-transaction)
+fi
+
+# --- Non-transactional table check ---
+
+# Names the tables in $1 that --single-transaction cannot snapshot consistently.
+#
+# Advisory only: every failure path here warns and returns. A backup must not be
+# abandoned because a diagnostic query could not run -- that would turn a missing
+# warning into a missing backup, which is strictly worse than the risk it warns
+# about.
+warn_non_transactional_tables() {
+    local db="$1"
+    local candidate client="" tables table
+
+    # Alpine's mariadb-client installs the client as `mariadb` and has so far also
+    # shipped a `mysql` compatibility symlink. Resolve whichever exists instead of
+    # betting on that symlink outliving a package update.
+    for candidate in mariadb mysql; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            client="$candidate"
+            break
+        fi
+    done
+
+    if [[ -z "$client" ]]; then
+        echo "Warning: no MySQL client found, skipping the non-transactional table check for '$db'" >&2
+        return
+    fi
+
+    # The database name is passed as an argument and read back with DATABASE()
+    # rather than interpolated into the SQL, so a name containing a quote cannot
+    # break out of the statement.
+    if ! tables=$(timeout -k "$TIMEOUT_GRACE" "$ENGINE_CHECK_TIMEOUT" \
+            "$client" "${mysql_conn_args[@]}" --batch --skip-column-names "$db" -e "
+                SELECT CONCAT(TABLE_NAME, ' (', IFNULL(ENGINE, 'unknown engine'), ')')
+                FROM information_schema.TABLES
+                WHERE TABLE_SCHEMA = DATABASE()
+                  AND TABLE_TYPE = 'BASE TABLE'
+                  AND (ENGINE IS NULL OR ENGINE <> 'InnoDB')
+                ORDER BY TABLE_NAME"); then
+        echo "Warning: could not check '$db' for non-transactional tables, continuing" >&2
+        return
+    fi
+
+    [[ -z "$tables" ]] && return
+
+    echo "Warning: MYSQL_SINGLE_TRANSACTION is enabled but '$db' has non-transactional tables:" >&2
+    while IFS= read -r table; do
+        echo "Warning:   $table" >&2
+    done <<< "$tables"
+    echo "Warning: these are dumped outside the transaction and a concurrent write can tear them." >&2
+    echo "Warning: convert them to InnoDB, or unset MYSQL_SINGLE_TRANSACTION to lock instead." >&2
+}
 
 # --- Build s5cmd arguments ---
 
@@ -149,6 +254,10 @@ for db in "${databases[@]}"; do
 
     dump_file="/tmp/${db}_${timestamp}.sql.gz"
     echo "Dumping MySQL database: $db"
+
+    if (( single_transaction )); then
+        warn_non_transactional_tables "$db"
+    fi
 
     # NOTE: the dump is buffered to /tmp rather than streamed to S3 (s5cmd has
     # a `pipe` subcommand that would allow streaming). That is deliberate: it


### PR DESCRIPTION
Adds `MYSQL_SINGLE_TRANSACTION`, opt-in and off by default, plus a warning that names non-transactional tables when it is on.

Fixes #13

## Why opt-in

The issue's MyISAM argument holds, and there is a second reason: this is a published image. Flipping the default would change what "a valid backup" means for every existing deployment on the next pull, with no error and no log line. A backup tool should not do that silently on an upgrade.

## What is in it

- `MYSQL_SINGLE_TRANSACTION` accepts `1`/`0`, `true`/`false`, `yes`/`no`, `on`/`off`. Anything else is rejected at startup rather than being silently treated as off.
- The connection arguments are factored into a shared array so the engine check talks to the same server, as the same user, as the dump it warns about.
- When enabled, `information_schema` is queried before each dump and any non-InnoDB base table is named in the log. The database is passed as an argument and read back with `DATABASE()` rather than interpolated into the SQL.
- The check is advisory. Client missing, query denied, query timed out — each warns and continues. A missing warning must never become a missing backup.
- Worst-case wall clock grows by 30s per database when enabled; the timeout budget comment is updated to match (1530s per database, 3060s for two, still inside the 3600s `activeDeadlineSeconds` both deployments use).

## Verification

Ran end-to-end on k3s — MariaDB 12.0.2 and MySQL 8.0.46, dumping to MinIO through the real image entrypoint:

- A user granted only `SELECT, SHOW VIEW, TRIGGER` **succeeds** with the flag and **fails** without it (`Access denied … when using LOCK TABLES`), on both servers. That is the reduced grant set the README now documents, and it is also conclusive proof the flag reaches `mysqldump`.
- The engine check lists exactly the non-InnoDB base tables (MyISAM, Aria, MEMORY), excludes views, and stays silent on an all-InnoDB schema.
- Boolean parsing: `true` runs, `maybe` exits 1 with the error message.

Observed log from the mixed-engine run:

```
Dumping MySQL database: mixeddb
Warning: MYSQL_SINGLE_TRANSACTION is enabled but 'mixeddb' has non-transactional tables:
Warning:   t_aria (Aria)
Warning:   t_memory (MEMORY)
Warning:   t_myisam (MyISAM)
Warning: these are dumped outside the transaction and a concurrent write can tear them.
Warning: convert them to InnoDB, or unset MYSQL_SINGLE_TRANSACTION to lock instead.
```

`shellcheck --severity=style` is clean.

## Docs

New README section, *Dump consistency and locking*, with a comparison table and the grant sets for both modes. It also states something that was not written down before: **neither mode gives a consistent snapshot across databases** — with a comma-separated `MYSQL_DATABASE` each database is dumped by its own `mysqldump` invocation, so the lock/transaction windows do not line up.

## Noted while testing, not addressed here

The image's `mariadb-client` cannot authenticate against a stock MySQL 8.0 server: no `caching_sha2_password` plugin in the Alpine package, and the default TLS cert is self-signed. Only users created with `mysql_native_password` work. Pre-existing and out of scope, but the README does advertise MySQL support — worth its own issue.
